### PR TITLE
Update .gitignore: se agregó el tipo de archivo .pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 results/
 .DS_Store
 ../.DS_Store
+*.pyc


### PR DESCRIPTION
Hola @shirleyah 

Debido a que el código del repositorio está basado en Python, es recomendable agregar a **.gitignore** el formato de archivo _.pyc_ para que estos archivos no sean controlados. 